### PR TITLE
Fix segmentation violation in concurrent lookup

### DIFF
--- a/cuckoo.go
+++ b/cuckoo.go
@@ -352,8 +352,8 @@ func (f *Filter) UInsertUnique(x []byte) bool {
 
 // Lookup checks if item exists in filter
 func (f *Filter) Lookup(x []byte) bool {
-	f.L.RLock()
-	defer f.L.RUnlock()
+	f.L.Lock()
+	defer f.L.Unlock()
 
 	return f.ULookup(x)
 }


### PR DESCRIPTION
`lookup` is not thread safe. Read lock is unable to prevent internal concurrently call on `hashOf`, which will cause segmentation violation. 